### PR TITLE
bump max faraday version

### DIFF
--- a/message_media_messages.gemspec
+++ b/message_media_messages.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://developers.messagemedia.com'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10')
+  s.add_dependency('faraday', '>= 0.10', '<= 2.0')
   s.add_dependency('test-unit', '~> 3.1.5')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
   s.add_dependency('faraday-http-cache', '~> 1.2.2')


### PR DESCRIPTION
increases the max faraday version to allow for 1.0+ versions

In the upgrading guide for 1.0 (https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-10) there's nothing that applies to this repo.